### PR TITLE
Use FLAC as dynamic library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 
 
-set(FLAC_LIBS FLAC++.a FLAC.a ogg.a)
+set(FLAC_LIBS FLAC++.so FLAC.so ogg.so)
 
 
 


### PR DESCRIPTION
Link against the FLAC dynamic library instead of the static one.

The static libraries are nowhere to be found on both my workstation with Arch Linux and Raspberry Pi OS.