### PR TITLE
Adds an additional type of normalization type in Cab IR module

### DIFF
--- a/src/ToobAmp.lv2/ttl.in/CabIR.ttl.in
+++ b/src/ToobAmp.lv2/ttl.in/CabIR.ttl.in
@@ -290,12 +290,34 @@ Limitations of Liability that apply to these works.
                 ];
                 rdfs:comment "Removes leading silence in impulse when set to false." ;
         ],  
+        [
+                a lv2:InputPort ,
+                lv2:ControlPort ;
 
+                lv2:index 6 ;
+                lv2:symbol "normalization_type" ;
+                lv2:name "Normalize" ;
+
+                lv2:portProperty lv2:enumeration ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 1 ;
+
+                lv2:scalePoint [
+                        rdfs:label "RMS" ;
+                        rdf:value 0
+                ],
+                [
+                        rdfs:label "Peak" ;
+                        rdf:value 1
+                ];
+                rdfs:comment "Normalization method for impulse response files." ;
+        ],
         [
                 a lv2:OutputPort ,
                 lv2:ControlPort ;
 
-                lv2:index 6 ;
+                lv2:index 7 ;
                 lv2:symbol "loading_state" ;
                 lv2:name "Status";
 
@@ -335,14 +357,14 @@ Limitations of Liability that apply to these works.
         [
                 a lv2:AudioPort ,
                         lv2:InputPort ;
-                lv2:index 7 ;
+                lv2:index 8 ;
                 lv2:symbol "in" ;
                 lv2:name "In"
         ],
         [
                 a lv2:AudioPort ,
                         lv2:OutputPort ;
-                lv2:index 8 ;
+                lv2:index 9 ;
                 lv2:symbol "out" ;
                 lv2:name "Out"
         ],
@@ -354,7 +376,7 @@ Limitations of Liability that apply to these works.
                 lv2:designation lv2:control ;
                 atom:supports patch:Message ;
 
-                lv2:index 9 ;
+                lv2:index 10 ;
                 lv2:symbol "control" ;
                 lv2:name "Control" ;
                 rdfs:comment "Control" ;
@@ -364,7 +386,7 @@ Limitations of Liability that apply to these works.
                 atom:bufferType atom:Sequence ;
                 # atom:supports patch:Message;
                 lv2:designation lv2:control ;
-                lv2:index 10;
+                lv2:index 11;
                 lv2:symbol "notify" ;
                 lv2:name "Notify" ;
                 rdfs:comment "Notification" ;

--- a/src/ToobConvolutionReverb.cpp
+++ b/src/ToobConvolutionReverb.cpp
@@ -245,6 +245,9 @@ void ToobConvolutionReverbBase::ConnectPort(uint32_t port, void *data)
         case CabIrPortId::PREDELAY:
             this->pPredelayObsolete = (float *)data;
             break;
+        case CabIrPortId::NORMALIZATION_TYPE:
+            this->pNormalizationType = (const float *)data;
+            break;
         case CabIrPortId::LOADING_STATE:
             this->pLoadingState = (float *)data;
             if (this->pLoadingState)
@@ -342,6 +345,15 @@ void ToobConvolutionReverbBase::UpdateControls()
     {
         fgMixOptions.decay = *pDecay;
         mixOptionsChanged = true;
+    }
+    if (pNormalizationType != nullptr && pluginType == PluginType::CabIr)
+    {
+        int normType = (int)(*pNormalizationType);
+        if (fgMixOptions.normalizationType != normType)
+        {
+            fgMixOptions.normalizationType = normType;
+            mixOptionsChanged = true;
+        }
     }
     if (fgMixOptions.maxTime != *pTime)
     {
@@ -924,6 +936,48 @@ static void NormalizeConvolution(AudioData &data)
     }
 }
 
+static void PeakNormalizeConvolution(AudioData &data)
+{
+    if (HasDiracImpulse(data))
+    {
+        return;
+    }
+    size_t size = data.getSize();
+
+    double peakAmplitude = 0;
+    for (size_t c = 0; c < data.getChannelCount(); ++c)
+    {
+        auto &channel = data.getChannel(c);
+        for (size_t i = 0; i < size; ++i)
+        {
+            double absVal = std::abs((double)channel[i]);
+            if (absVal > peakAmplitude)
+            {
+                peakAmplitude = absVal;
+            }
+        }
+    }
+
+    if (peakAmplitude == 0)
+    {
+        return;
+    }
+
+    // -7dB attenuation to match perceived loudness of RMS normalization
+    constexpr double DB_REDUCTION = -7.0;
+    double attenuation = std::pow(10.0, DB_REDUCTION / 20.0);
+
+    float scale = (float)(attenuation / peakAmplitude);
+    for (size_t c = 0; c < data.getChannelCount(); ++c)
+    {
+        auto &channel = data.getChannel(c);
+        for (size_t i = 0; i < size; ++i)
+        {
+            channel[i] *= scale;
+        }
+    }
+}
+
 static void RemovePredelay(AudioData &audioData)
 {
     std::vector<float> &channel = audioData.getChannel(0);
@@ -1202,13 +1256,19 @@ AudioData ToobConvolutionReverbBase::LoadWorker::LoadFile(const std::filesystem:
     // using clock_t = std::chrono::steady_clock;
     // clock_t::time_point start = clock_t::now();
 
-    if (this->bgMixOptions.version >= CrvbVersion::V2)
+    if (pThis->pluginType == PluginType::CabIr)
     {
-        NormalizeConvolution(data);
+        if (this->bgMixOptions.normalizationType == 1)
+            PeakNormalizeConvolution(data);
+        else
+            NormalizeConvolution(data);
     }
     else
     {
-        LegacyNormalizeConvolution(data);
+        if (this->bgMixOptions.version >= CrvbVersion::V2)
+            NormalizeConvolution(data);
+        else
+            LegacyNormalizeConvolution(data);
     }
 
     // auto duration = clock_t::now()-start;

--- a/src/ToobConvolutionReverb.h
+++ b/src/ToobConvolutionReverb.h
@@ -64,6 +64,7 @@ namespace toob
         float width = -999;
         float pan = -9999;
         float maxTime = 30.0;
+        int normalizationType = 0; // 0 = RMS, 1 = Peak
     };
 
 	class ToobConvolutionReverbBase : public Lv2PluginWithState
@@ -123,6 +124,7 @@ namespace toob
 			TIME,
 			DIRECT_MIX,
 			PREDELAY,
+			NORMALIZATION_TYPE,
 			LOADING_STATE,
 			AUDIO_INL,
 			AUDIO_OUTL,
@@ -373,6 +375,7 @@ namespace toob
 		const float *pPredelayObsolete = nullptr;
 
 		const float *pPredelayNew = nullptr;
+		const float *pNormalizationType = nullptr;
 		const float *pStartOffset = nullptr;
 		const float *pStretch = nullptr;
 		const float *pDecay = nullptr;


### PR DESCRIPTION
This PR adds the possibility to select Cab IR normalization type.

The CAB IR plugin already has RMS normalization, but I believe it is interesting to add the option to normalize by peak, as it seems to be more common for use with IRs. I'm keeping the default with the existing option for compatibility.

In some plugins, I noticed that a -18dB drop is applied after normalization, but here that would make the IR sound very quiet, so I applied -7dB, which on average normalizes by peak but keeps the perceived volume close to RMS normalization.

Here's how it looks in my RPI4:
<img width="1462" height="240" alt="20260410_230741" src="https://github.com/user-attachments/assets/045a2908-8420-4784-b6a1-e2cb8cd0e5dd" />

For me, this normalization has been useful. If you think it could be useful for more users, I am available for adjustments in the code or the target branch.

