### PR TITLE
Fix output-level metadata reported to the host (wrong getter, unstored flag)

### DIFF
--- a/src/NeuralAmpModeler.cpp
+++ b/src/NeuralAmpModeler.cpp
@@ -391,17 +391,16 @@ void NeuralAmpModeler::SetModel()
         {
             fgModelMetadata.input_level_dbu = 0;
         }
-        fgModelMetadata.flags = flags;
-
         if (mNAM->HasModelOutputLevelDBu())
         {
             flags |= TOOB_NAM_METADATA_FLAGS::has_output_level_dbu;
-            fgModelMetadata.output_level_dbu = mNAM->GetModelInputLevelDBu();
+            fgModelMetadata.output_level_dbu = mNAM->GetModelOutputLevelDBu();
         }
         else
         {
             fgModelMetadata.output_level_dbu = 0;
         }
+        fgModelMetadata.flags = flags;
 
         if (this->backgroundProcessorState != BackgroundProcessorState::ForegroundProcessing)
         {


### PR DESCRIPTION
Two independent bugs in the same block of `NeuralAmpModeler::SetModel()`, both affecting the model metadata published to the host.

## 1. Output level reported as input level

```cpp
fgModelMetadata.output_level_dbu = mNAM->GetModelInputLevelDBu();
```

Should be `GetModelOutputLevelDBu()`. That method exists and is already used correctly in `NamBackgroundProcessor.cpp`.

## 2. `has_output_level_dbu` flag never stored

```cpp
fgModelMetadata.flags = flags;          // <- assigned here

if (mNAM->HasModelOutputLevelDBu())
{
    flags |= TOOB_NAM_METADATA_FLAGS::has_output_level_dbu;   // <- set after
    ...
}
```

The bit is OR-ed into the local `flags` after `fgModelMetadata.flags` has already been written, so it never reaches the struct. `has_input_level_dbu` is set before the assignment and was unaffected — which is presumably why this went unnoticed.

The fix moves the assignment below the output-level block. No other reordering.

## Why it matters

Both values are sent to the host in `SendModelMetadataNotification()`:

```cpp
values[TOOB_NAM_METADATA_OFFSETS::flags]            = fgModelMetadata.flags;
values[TOOB_NAM_METADATA_OFFSETS::output_level_dbu] = fgModelMetadata.output_level_dbu;
```

So a host reading this metadata currently gets a wrong output level, and never sees the flag that says one is available. Inside ToobAmp itself the flag isn't consumed, which is consistent with this only being visible from the host side.

## Scope and verification

Seven lines, one function, no behavioural change to anything else. I have **not** built this — I don't have a ToobAmp build environment set up, and I'd rather say so than imply I did. The change is small enough to read, but please compile it before trusting me.

Found while investigating NAM calibration behaviour for PiPedal (rerdavies/pipedal#555). The larger calibration-semantics question from that discussion is deliberately **not** part of this PR — that's a design decision for you, whereas these two are unambiguous.

## Provenance

As discussed in rerdavies/pipedal#555: I'm not a developer, and this is AI-implemented from my description of the problem. Please review accordingly.
